### PR TITLE
Add Cargo's --jobs flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,10 @@ pub struct Args {
     /// Invert the tree direction
     pub invert: bool,
 
+    #[structopt(long = "jobs", short = "j")]
+    /// Number of parallel jobs, defaults to # of CPUs
+    pub jobs: u32,
+
     #[structopt(long = "verbose", short = "v", parse(from_occurrences))]
     /// Use verbose cargo output (-vv very verbose)
     pub verbose: u32,
@@ -111,6 +115,9 @@ pub fn build_compile_options<'a>(args: &'a Args, config: &'a cargo::Config) -> C
     opt.features = features.collect::<_>();
     opt.all_features = args.all_features;
     opt.no_default_features = args.no_default_features;
+
+    // BuildConfig, see https://docs.rs/cargo/0.31.0/cargo/core/compiler/struct.BuildConfig.html
+    opt.build_config.jobs = args.jobs;
 
     opt
 }


### PR DESCRIPTION
This can help debugging Siderophile itself (or rather the build it
launches under the hood) or simply lowering the resources it takes.