### PR TITLE
Add support for cratenames with dashes

### DIFF
--- a/analyze.sh
+++ b/analyze.sh
@@ -38,6 +38,7 @@ fi
 
 # The name of the crate we're analyzing
 CRATENAME=$1
+CRATENAME=${CRATENAME//-/_}
 
 # The folder that this bash file is in
 SIDEROPHILE_PATH=$(dirname "$0")


### PR DESCRIPTION
Before this commit running `./analyze.sh some-crate` will fail to find
the proper files later on as they are named as `some_crate.<something>`.