### PR TITLE
Add verbose cargo errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,10 @@ mod callgraph_gen;
 mod trawl_source;
 mod utils;
 
-use std::collections::HashMap;
-use structopt::StructOpt;
 use cargo::core::shell::Shell;
 use cargo::util::errors::CliError;
+use std::collections::HashMap;
+use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 pub struct Args {
@@ -61,6 +61,6 @@ fn main() {
         Err(e) => {
             let mut shell = Shell::new();
             cargo::exit_with_error(e, &mut shell);
-        },
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ mod utils;
 
 use std::collections::HashMap;
 use structopt::StructOpt;
+use cargo::core::shell::Shell;
+use cargo::util::errors::CliError;
 
 #[derive(StructOpt, Debug)]
 pub struct Args {
@@ -25,7 +27,7 @@ pub struct Args {
     include_tests: bool,
 }
 
-fn real_main() -> anyhow::Result<HashMap<String, u32>> {
+fn real_main() -> anyhow::Result<HashMap<String, u32>, CliError> {
     let args = Args::from_args();
 
     let config = cargo::Config::default()?;
@@ -56,7 +58,9 @@ fn main() {
                 println!("    {:03}  {}", badness, label)
             }
         }
-        // TODO: add proper tracebacks or something
-        Err(e) => println!("error: {}", e),
+        Err(e) => {
+            let mut shell = Shell::new();
+            cargo::exit_with_error(e, &mut shell);
+        },
     }
 }

--- a/src/trawl_source/ast_walker.rs
+++ b/src/trawl_source/ast_walker.rs
@@ -258,13 +258,10 @@ fn without_lifetimes(mut path: syn::Path) -> syn::Path {
     for seg in path.segments.iter_mut() {
         if let PathArguments::AngleBracketed(ref mut generic_args) = seg.arguments {
             // First remove all the lifetime arguments from this path
-            let non_lifetime_args = generic_args.args.iter().filter(|a| {
-                if let GenericArgument::Lifetime(_) = a {
-                    false
-                } else {
-                    true
-                }
-            });
+            let non_lifetime_args = generic_args
+                .args
+                .iter()
+                .filter(|a| !matches!(a, GenericArgument::Lifetime(_)));
 
             // Now go into every type in the generic arguments and remove their lifetimes too. This
             // handles examples like <http::header::name::HeaderName as From<HdrName<'a>>>::from


### PR DESCRIPTION
When Cargo fails to parse the project's root manifest file (`./Cargo.toml`), Siderophile does not print out the reason and just ends up with:

```
$ siderophile ...
error: failed to parse manifest at `failed to parse manifest at blablabla/Cargo.toml`
```

We can of course use `RUST_LOG=cargo=trace` but this doesn't give much info:
```
$ RUST_LOG=cargo=trace siderophile --crate-name xxx
[2020-10-15T15:26:58Z TRACE cargo::util::config] get cv ConfigKey { env: "CARGO_BUILD", parts: [("build", 5)] }
[2020-10-15T15:26:58Z TRACE cargo::util::config] get cv ConfigKey { env: "CARGO_BUILD_RUSTFLAGS", parts: [("build", 5), ("rustflags", 11)] }
[2020-10-15T15:26:58Z TRACE cargo::util::config] get cv ConfigKey { env: "CARGO_BUILD_RUSTFLAGS", parts: [("build", 5), ("rustflags", 11)] }
[2020-10-15T15:26:58Z TRACE cargo::util::toml] read_manifest; path=/home/disconnect3d/projectpath/Cargo.toml; source-id=/home/disconnect3d/projectpath
```

This PR was inspired from the log I received in `cargo geiger`:
```
$ cargo geiger
error: failed to parse manifest at `/home/disconnect3d/projectpath/Cargo.toml`
Caused by:
  the cargo feature `resolver` requires a nightly version of Cargo, but this is the `dev` channel
See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
```

and their code - https://github.com/rust-secure-code/cargo-geiger/blob/master/cargo-geiger/src/main.rs#L117-L119