### PR TITLE
Add mark source option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Install LLVM 10
+      - name: Install LLVM 11
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -29,7 +29,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Install LLVM 10
+    - name: Install LLVM 11
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install LLVM 10
-        run: sudo apt-get install llvm-10
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 11
       - uses: actions/checkout@v2
       - name: Format
         run: cargo fmt && git diff --exit-code
@@ -27,7 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install LLVM 10
-      run: sudo apt-get install llvm-10
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 11
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,6 +1032,7 @@ dependencies = [
  "rustc-demangle",
  "structopt",
  "syn",
+ "tempfile",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,15 +626,15 @@ dependencies = [
 
 [[package]]
 name = "llvm-sys"
-version = "100.2.0"
+version = "110.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9109e19fbfac3458f2970189719fa19f1007c6fd4e08c44fdebf4be0ddbe261d"
+checksum = "b0062a0c6635fb5d57c6ebba072dcae50e41651030363cf06d220b0d016840f2"
 dependencies = [
  "cc",
  "lazy_static",
  "libc",
  "regex",
- "semver 0.9.0",
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -734,6 +734,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "pkg-config"
@@ -931,21 +940,21 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
  "serde",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.1",
 ]
 
 [[package]]
@@ -953,6 +962,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1172,6 +1190,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ structopt = "0.3"
 syn = { version = "1.0", features = ["full", "visit"] }
 walkdir = "2.3"
 regex = "1"
-llvm-ir = {version = "0.7.4", features = ["llvm-10"]}
+llvm-ir = {version = "0.7.4", features = ["llvm-11"]}
 anyhow = "1"
 rustc-demangle = "0.1"
 glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,5 @@ llvm-ir = {version = "0.7.4", features = ["llvm-11"]}
 anyhow = "1"
 rustc-demangle = "0.1"
 glob = "0.3"
+tempfile = "3.1.0"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Badness  Function
 Make sure that you have the following requirements:
 
   * `rustup` and `cargo` must be installed and in your `PATH`
-  * LLVM 8, 9, or 10 must be available (see https://crates.io/crates/llvm-ir, if you're using a version besides 11, you'll need to change the feature in Siderophile's Cargo.toml before you compile)
+  * LLVM 11 is required. Older versions such as LLVM 8, 9 or 10 may work (see https://crates.io/crates/llvm-ir) but require the `llvm-ir` package's features change in `Cargo.toml` before compiling Siderophile.
   
 Then, run `cargo build --release`, and you'll have a Siderophile binary :)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Badness  Function
 Make sure that you have the following requirements:
 
   * `rustup` and `cargo` must be installed and in your `PATH`
-  * LLVM 8, 9, or 10 must be available (see https://crates.io/crates/llvm-ir, if you're using a version besides 9, you'll need to change the feature in Siderophile's Cargo.toml before you compile)
+  * LLVM 8, 9, or 10 must be available (see https://crates.io/crates/llvm-ir, if you're using a version besides 11, you'll need to change the feature in Siderophile's Cargo.toml before you compile)
   
 Then, run `cargo build --release`, and you'll have a Siderophile binary :)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ pub struct Args {
     include_tests: bool,
 }
 
-fn real_main() -> anyhow::Result<HashMap<String, u32>, CliError> {
+fn real_main() -> anyhow::Result<HashMap<String, (u32, utils::LabelInfo)>, CliError> {
     let args = Args::from_args();
 
     let config = cargo::Config::default()?;
@@ -52,7 +52,7 @@ fn main() {
         Ok(badness) => {
             println!("Badness  Function");
             let mut badness_out_list: Vec<(&str, &u32)> =
-                badness.iter().map(|(a, b)| (a as &str, b)).collect();
+                badness.iter().map(|(a, (b, _))| (a as &str, b)).collect();
             badness_out_list.sort_by_key(|(a, b)| (std::u32::MAX - *b, *a));
             for (label, badness) in badness_out_list {
                 println!("    {:03}  {}", badness, label)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,20 @@
 extern crate log;
 
 mod callgraph_gen;
+mod mark_source;
 mod trawl_source;
 mod utils;
 
 use cargo::core::shell::Shell;
 use cargo::util::errors::CliError;
 use std::collections::HashMap;
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 
 #[derive(StructOpt, Debug)]
+#[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
 pub struct Args {
     #[structopt(long = "crate-name", value_name = "NAME")]
-    /// crate name
+    /// Crate name
     crate_name: String,
 
     #[structopt(long = "package", short = "p", value_name = "SPEC")]
@@ -25,11 +27,12 @@ pub struct Args {
     #[structopt(long = "include-tests")]
     /// Count unsafe usage in tests.
     include_tests: bool,
+
+    #[structopt(flatten)]
+    mark_opts: mark_source::MarkOpts,
 }
 
-fn real_main() -> anyhow::Result<HashMap<String, (u32, utils::LabelInfo)>, CliError> {
-    let args = Args::from_args();
-
+fn real_main(args: &Args) -> anyhow::Result<HashMap<String, (u32, utils::LabelInfo)>, CliError> {
     let config = cargo::Config::default()?;
     let workspace_root = cargo::util::important_paths::find_root_manifest_for_wd(config.cwd())?;
     let ws = cargo::core::Workspace::new(&workspace_root, &config)?;
@@ -37,7 +40,7 @@ fn real_main() -> anyhow::Result<HashMap<String, (u32, utils::LabelInfo)>, CliEr
     // new language, same horrible horrible hack. see PR#22 and related issues, this makes me sad....
     utils::configure_rustup_toolchain();
 
-    let tainted = trawl_source::get_tainted(&config, &ws, args.package, args.include_tests)?;
+    let tainted = trawl_source::get_tainted(&config, &ws, &args.package, args.include_tests)?;
     let callgraph = callgraph_gen::gen_callgraph(&ws, &args.crate_name)?;
     Ok(callgraph_gen::trace_unsafety(
         callgraph,
@@ -46,9 +49,10 @@ fn real_main() -> anyhow::Result<HashMap<String, (u32, utils::LabelInfo)>, CliEr
     ))
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     env_logger::init();
-    match real_main() {
+    let args = Args::from_args();
+    match real_main(&args) {
         Ok(badness) => {
             println!("Badness  Function");
             let mut badness_out_list: Vec<(&str, &u32)> =
@@ -57,10 +61,12 @@ fn main() {
             for (label, badness) in badness_out_list {
                 println!("    {:03}  {}", badness, label)
             }
+            mark_source::mark_source(&args.mark_opts, &badness)?;
         }
         Err(e) => {
             let mut shell = Shell::new();
             cargo::exit_with_error(e, &mut shell);
         }
     }
+    Ok(())
 }

--- a/src/mark_source.rs
+++ b/src/mark_source.rs
@@ -1,0 +1,108 @@
+use crate::utils::LabelInfo;
+use anyhow::Result;
+use regex::Regex;
+use std::collections::HashMap;
+use std::fs::{copy, File};
+use std::io::{BufRead, BufReader, LineWriter, Write};
+use std::path::{Path, PathBuf};
+use structopt::StructOpt;
+use tempfile::NamedTempFile;
+
+type BadnessMap = HashMap<String, (u32, LabelInfo)>;
+
+#[derive(StructOpt, Debug)]
+pub struct MarkOpts {
+    #[structopt(long = "mark", value_name = "TEXT")]
+    /// Mark bad functions with TEXT
+    mark: Option<String>,
+
+    #[structopt(long = "no-mark-closures")]
+    /// Do not mark closures
+    no_mark_closures: bool,
+
+    #[structopt(long = "threshold", value_name = "BADNESS", default_value)]
+    /// Minimum badness required to mark a function
+    threshold: u32,
+}
+
+pub fn mark_source(opts: &MarkOpts, badness: &BadnessMap) -> Result<()> {
+    let text = if let Some(text) = &opts.mark {
+        text
+    } else {
+        return Ok(());
+    };
+
+    let grouped = group_by_path(badness);
+
+    for entry in grouped {
+        mark_path(opts, text, &entry.0, &entry.1)?;
+    }
+
+    Ok(())
+}
+
+fn group_by_path(badness: &BadnessMap) -> HashMap<PathBuf, BadnessMap> {
+    let mut grouped = HashMap::new();
+    for entry in badness {
+        if let Some(debugloc) = &entry.1 .1.debugloc {
+            let path = debugloc
+                .directory
+                .as_ref()
+                .map_or(PathBuf::from(&debugloc.filename), |directory| {
+                    PathBuf::from(directory).join(&debugloc.filename)
+                });
+            grouped
+                .entry(path)
+                .or_insert_with(HashMap::new)
+                .insert(entry.0.clone(), entry.1.clone());
+        }
+    }
+    grouped
+}
+
+fn mark_path(opts: &MarkOpts, text: &str, path: &Path, badness: &BadnessMap) -> Result<()> {
+    let line_numbers = extract_line_numbers(opts, badness);
+
+    let source = File::open(path)?;
+    let reader = BufReader::new(source);
+
+    let tempfile = NamedTempFile::new()?;
+    let mut writer = LineWriter::new(&tempfile);
+
+    for (i, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line_numbers.binary_search(&(i + 1)).is_ok() {
+            let spaces = Regex::new(r"^\s*").unwrap().find(&line).unwrap().as_str();
+            writeln!(writer, "{}{}", spaces, text)?;
+        }
+        writeln!(writer, "{}", line)?;
+    }
+
+    drop(writer);
+
+    copy(tempfile.path(), path)?;
+
+    Ok(())
+}
+
+fn extract_line_numbers(opts: &MarkOpts, badness: &BadnessMap) -> Vec<usize> {
+    let mut line_numbers = badness
+        .iter()
+        .filter_map(|entry| {
+            if (!opts.no_mark_closures || !entry.0.ends_with("{{closure}}"))
+                && entry.1 .0 >= opts.threshold
+            {
+                entry
+                    .1
+                     .1
+                    .debugloc
+                    .as_ref()
+                    .map(|debugloc| debugloc.line as usize)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    line_numbers.sort_unstable();
+    line_numbers
+}

--- a/src/trawl_source/mod.rs
+++ b/src/trawl_source/mod.rs
@@ -451,7 +451,7 @@ impl Executor for CustomExecutor {
 pub fn get_tainted(
     config: &cargo::Config,
     workspace: &cargo::core::Workspace,
-    _package: Option<String>,
+    _package: &Option<String>,
     include_tests: bool,
 ) -> anyhow::Result<Vec<String>> {
     let (packages, _resolve) = cargo::ops::resolve_ws(&workspace)?;

--- a/src/trawl_source/mod.rs
+++ b/src/trawl_source/mod.rs
@@ -199,8 +199,8 @@ fn get_many<'a>(
 }
 
 /// Finds and outputs all unsafe things to the given file
-pub(crate) fn find_unsafe_in_packages<'a, 'b>(
-    packs: &'a PackageSet<'b>,
+pub(crate) fn find_unsafe_in_packages(
+    packs: &PackageSet,
     mut rs_files_used: HashMap<PathBuf, u32>,
     allow_partial_results: bool,
     include_tests: bool,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,10 +63,11 @@ mod tests {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct LabelInfo {
     pub short_label: Option<String>,
     pub caller_labels: HashSet<String>,
+    pub debugloc: Option<llvm_ir::DebugLoc>,
 }
 
 impl LabelInfo {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,10 +63,21 @@ mod tests {
     }
 }
 
+#[derive(Default)]
+pub struct LabelInfo {
+    pub short_label: Option<String>,
+    pub caller_labels: HashSet<String>,
+}
+
+impl LabelInfo {
+    pub fn new() -> LabelInfo {
+        Default::default()
+    }
+}
+
 pub struct CallGraph {
-    pub label_to_caller_labels: HashMap<String, HashSet<String>>,
+    pub label_to_label_info: HashMap<String, LabelInfo>,
     pub short_label_to_labels: HashMap<String, HashSet<String>>,
-    pub label_to_short_label: HashMap<String, String>,
 }
 
 pub fn configure_rustup_toolchain() {


### PR DESCRIPTION
This PR adds a `--mark <TEXT>` option, which marks bad functions with `TEXT`.

For example, if `bar` is a bad function in crate `foo`, then
```sh
siderophile --crate-name foo --mark '// XXX: Bad function'
```
will insert `// XXX: Bad function` just before `bar`'s declaration in `foo`, e.g.:
```rust
    // XXX: Bad function
    fn bar() { ...
```
Of course, `TEXT` is not limited to just comments.

This PR also adds two related options:
* `--no-mark-closures`: Mark only named functions
* `--threshold BADNESS`: Require at least `BADNESS` to mark a function