### PR TITLE
Better error handling, simplify command line, performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,8 +81,9 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.50.1"
-source = "git+https://github.com/rust-lang/cargo.git?rev=d61c808dda8029721042618f22e8e15d01328af4#d61c808dda8029721042618f22e8e15d01328af4"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca7e53bf83eb8f6254a37ac45822003c05f6053c09b58795de76a3d6c84eda8a"
 dependencies = [
  "anyhow",
  "atty",
@@ -118,6 +119,7 @@ dependencies = [
  "num_cpus",
  "opener",
  "percent-encoding",
+ "rand",
  "rustc-workspace-hack",
  "rustfix",
  "same-file",
@@ -140,8 +142,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.1"
-source = "git+https://github.com/rust-lang/cargo.git?rev=d61c808dda8029721042618f22e8e15d01328af4#d61c808dda8029721042618f22e8e15d01328af4"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
  "serde",
 ]
@@ -212,8 +215,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crates-io"
-version = "0.31.1"
-source = "git+https://github.com/rust-lang/cargo.git?rev=d61c808dda8029721042618f22e8e15d01328af4#d61c808dda8029721042618f22e8e15d01328af4"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217138863f33507d7a8edef10fc673c4911679ef7aeb9ff53ee7bb82dc7bf590"
 dependencies = [
  "anyhow",
  "curl",
@@ -572,9 +576,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libgit2-sys"
@@ -1152,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.33"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0bcfbd6a598361fda270d82469fff3d65089dc33e175c9a131f7b4cd395f228"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
  "libc",
@@ -1275,9 +1279,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ name = "siderophile"
 path = "src/main.rs"
 
 [dependencies]
-# https://github.com/rust-lang/cargo/issues/9124
-cargo = { version = "0.50.1", git = "https://github.com/rust-lang/cargo.git", rev = "d61c808dda8029721042618f22e8e15d01328af4" }
+cargo = { version = "0.53.0" }
 env_logger = "0.9"
 log = "0.4"
 structopt = "0.3"
@@ -29,5 +28,5 @@ llvm-ir = {version = "0.8.0", features = ["llvm-12"]}
 anyhow = "1"
 rustc-demangle = "0.1"
 glob = "0.3"
-tempfile = "3.1.0"
+tempfile = "3.2.0"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,18 +8,18 @@ mod mark_source;
 mod trawl_source;
 mod utils;
 
-use cargo::core::shell::Shell;
-use cargo::util::errors::CliError;
+use anyhow::anyhow;
+use cargo::{
+    core::{Package, Workspace},
+    util::Filesystem,
+};
 use std::collections::HashMap;
 use structopt::{clap, StructOpt};
+use tempfile::tempdir_in;
 
 #[derive(StructOpt, Debug)]
 #[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
 pub struct Args {
-    #[structopt(long = "crate-name", value_name = "NAME")]
-    /// Crate name
-    crate_name: String,
-
     #[structopt(long = "package", short = "p", value_name = "SPEC")]
     /// Package to be used as the root of the tree
     package: Option<String>,
@@ -32,41 +32,61 @@ pub struct Args {
     mark_opts: mark_source::MarkOpts,
 }
 
-fn real_main(args: &Args) -> anyhow::Result<HashMap<String, (u32, utils::LabelInfo)>, CliError> {
+fn real_main(args: &Args) -> anyhow::Result<HashMap<String, (u32, utils::LabelInfo)>> {
     let config = cargo::Config::default()?;
     let workspace_root = cargo::util::important_paths::find_root_manifest_for_wd(config.cwd())?;
     let ws = cargo::core::Workspace::new(&workspace_root, &config)?;
 
+    let mut ws = if let Some(name) = &args.package {
+        let package =
+            find_package(&ws, name).ok_or_else(|| anyhow!("Could not find package `{}`", name))?;
+        Workspace::ephemeral(package.clone(), &config, None, false)?
+    } else {
+        ws
+    };
+
+    let tempdir = tempdir_in(config.cwd())?;
+    ws.set_target_dir(Filesystem::new(tempdir.path().to_path_buf()));
+
+    let crate_name = crate_name(&ws, &args.package)?;
+
     // new language, same horrible horrible hack. see PR#22 and related issues, this makes me sad....
     utils::configure_rustup_toolchain();
 
+    // smoelius: `trawl_source::get_tainted` must be called before `callgraph_gen::gen_callgraph`
+    // because `get_tainted` performs the build.
     let tainted = trawl_source::get_tainted(&config, &ws, &args.package, args.include_tests)?;
-    let callgraph = callgraph_gen::gen_callgraph(&ws, &args.crate_name)?;
+    let callgraph = callgraph_gen::gen_callgraph(&ws, &crate_name)?;
     Ok(callgraph_gen::trace_unsafety(
         &callgraph,
-        &args.crate_name,
+        &crate_name,
         &tainted,
     ))
+}
+
+fn find_package<'ws>(ws: &'ws Workspace, name: &str) -> Option<&'ws Package> {
+    ws.members().find(|package| package.name() == name)
+}
+
+fn crate_name(ws: &Workspace, package: &Option<String>) -> anyhow::Result<String> {
+    package.as_ref().cloned().map_or_else(
+        || ws.current().map(|package| package.name().to_string()),
+        Ok,
+    )
 }
 
 fn main() -> anyhow::Result<()> {
     env_logger::init();
     let args = Args::from_args();
-    match real_main(&args) {
-        Ok(badness) => {
-            println!("Badness  Function");
-            let mut badness_out_list: Vec<(&str, &u32)> =
-                badness.iter().map(|(a, (b, _))| (a as &str, b)).collect();
-            badness_out_list.sort_by_key(|(a, b)| (std::u32::MAX - *b, *a));
-            for (label, badness) in badness_out_list {
-                println!("    {:03}  {}", badness, label);
-            }
-            mark_source::mark_source(&args.mark_opts, &badness)?;
+    real_main(&args).and_then(|badness| {
+        println!("Badness  Function");
+        let mut badness_out_list: Vec<(&str, &u32)> =
+            badness.iter().map(|(a, (b, _))| (a as &str, b)).collect();
+        badness_out_list.sort_by_key(|(a, b)| (std::u32::MAX - *b, *a));
+        for (label, badness) in badness_out_list {
+            println!("    {:03}  {}", badness, label);
         }
-        Err(e) => {
-            let mut shell = Shell::new();
-            cargo::exit_with_error(e, &mut shell);
-        }
-    }
-    Ok(())
+        mark_source::mark_source(&args.mark_opts, &badness)?;
+        Ok(())
+    })
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -20,7 +20,7 @@ for testdir in "${TESTS[@]}"; do
     echo ""
     pushd "${testdir}"
     rm -f ../output_badness.txt
-    ../../target/release/siderophile > ../output_badness.txt
+    ../../target/release/siderophile --crate-name "${testdir}" > ../output_badness.txt
     if ! (diff ../${testdir}_expected_badness.txt ../output_badness.txt); then
         echo ""
         echo -e "${WARN}[!!!] Tests failed on $testdir: the expected_badness.txt does not match the output_badness.txt file!${NC}"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -20,10 +20,16 @@ for testdir in "${TESTS[@]}"; do
     echo ""
     pushd "${testdir}"
     rm -f ../output_badness.txt
-    ../../target/release/siderophile --crate-name "${testdir}" > ../output_badness.txt
+    ../../target/release/siderophile > ../output_badness.txt
     if ! (diff ../${testdir}_expected_badness.txt ../output_badness.txt); then
         echo ""
         echo -e "${WARN}[!!!] Tests failed on $testdir: the expected_badness.txt does not match the output_badness.txt file!${NC}"
+        exit 1
+    fi
+    # smoelius: Verify that a temporary target directory was used.
+    if [[ -e target ]]; then
+        echo ""
+        echo -e "${WARN}[+++] Found $testdir/target, which should not exist!${NC}"
         exit 1
     fi
     popd


### PR DESCRIPTION
This PR does four things.
1. **Improve error handling.** Siderophile uses `anyhow`. One of the main benefits of using `anyhow` is backtraces when errors occur. But this only works if errors propagate all the way up to `main`'s return value. This PR makes that the case.
2. **Simplify the command line.** Previously, there were both `--package` and `--crate-name` options. This was silly because the crate name is determined by the package name. Now there is just `--package`.  As a side effect of this change, you can now run `siderophile` within a workspace (provide you specify a package).
3. **No more `cargo clean`.** To ensure that artifacts were built, `siderophile` would run `cargo clean` twice(!). Now, `siderophile` uses a temporary target directory. So, no more `cargo clean`, and no more blowing away the existing artifacts. As a side effect of this change, you can now run `siderophile` on its own package---`cargo run` is all it takes.
4. **Combine build steps.** Previously, `siderophile` would perform two build steps: one to find all of the `.rs` files, and one to generate the `.bc` files. The two steps have been combined so that both goals are accomplished in one build step.

Edit: I pushed an additional commit (77169d6b6c7f84abab05bd46269a9f2cce6de393) that deprecates `--crate-name` instead of removing it outright.