### PR TITLE
chore: cleanup

### DIFF
--- a/src/trawl_source/ast_walker.rs
+++ b/src/trawl_source/ast_walker.rs
@@ -12,13 +12,14 @@ use std::{
 
 use quote::ToTokens;
 use syn::{
-    punctuated::Punctuated, visit, Attribute, Expr, GenericArgument, ImplItemFn, ItemFn, ItemImpl,
-    ItemMod, ItemTrait, PathArguments, TraitItemFn,
+    punctuated::Punctuated, visit, Expr, GenericArgument, ImplItemFn, ItemFn, ItemImpl, ItemMod,
+    ItemTrait, PathArguments, TraitItemFn,
 };
 
 /// A formatted list of Rust items that are unsafe
 pub struct UnsafeItems(pub(crate) Vec<String>);
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum ScanFileError {
     Io(io::Error, PathBuf),

--- a/src/trawl_source/mod.rs
+++ b/src/trawl_source/mod.rs
@@ -23,6 +23,7 @@ use cargo::{
 use cargo_util::{paths, ProcessBuilder};
 use walkdir::{self, WalkDir};
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum RsResolveError {
     Walkdir(walkdir::Error),
@@ -369,6 +370,7 @@ struct CustomExecutor {
 use std::error::Error;
 use std::fmt;
 
+#[allow(dead_code)]
 #[derive(Debug)]
 enum CustomExecutorError {
     OutDirKeyMissing(String),


### PR DESCRIPTION
Fixup an import, hush some false-positive dead code warnings. The latter are probably a rustc bug; it's correct to emit a dead code warning for `Debug`, but the compiler doesn't seem to follow that the `Debug` impl is then used in an explicit `Display` impl.